### PR TITLE
re-remove pyssht, with right spin arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ install_requires =
     numpy
     h5py
     numba
-    pyssht
+    ssht_numba @ git+git://github.com/UPennEoR/ssht_numba
     scipy
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov

--- a/src/spin1_beam_model/cst_processing.py
+++ b/src/spin1_beam_model/cst_processing.py
@@ -135,8 +135,8 @@ class CSTDataProcessor(object):
             pos1_Elm = np.empty(self.L_data * self.L_data, dtype=np.complex128)
             sshtn.mw_forward_sov_conv_sym_ss(pos1_E, self.L_data, 1, pos1_Elm)
 
-            neg1_elm = np.empty(self.L_data * self.L_data, dtype=np.complex128)
-            sshtn.mw_forward_sov_conv_sym_ss(neg1_e, self.L_data, -1, neg1_Elm)
+            neg1_Elm = np.empty(self.L_data * self.L_data, dtype=np.complex128)
+            sshtn.mw_forward_sov_conv_sym_ss(neg1_E, self.L_data, -1, neg1_Elm)
 
             # pos1_Elm = pyssht.forward(
             #     pos1_E, self.L_data, Spin=1, Method="MWSS", Reality=False

--- a/src/spin1_beam_model/cst_processing.py
+++ b/src/spin1_beam_model/cst_processing.py
@@ -3,7 +3,7 @@ import os
 import h5py
 import numba as nb
 import numpy as np
-import pyssht
+import ssht_numba as sshtn
 
 
 @nb.njit
@@ -12,7 +12,7 @@ def ssht_power_spectrum(f_lm):
     C_l = np.zeros(L)
     for el in range(L):
         for m in range(-el, el + 1):
-            ind = el * el + el + m  # equivalent to pyssht.elm2ind(el, m)
+            ind = sshtn.elm2ind(el, m)
             C_l[el] += np.abs(f_lm[ind]) ** 2.0
         C_l[el] /= 2 * el + 1
     return C_l
@@ -111,7 +111,7 @@ class CSTDataProcessor(object):
             (self.Nfreq, self.L_data ** 2), dtype=np.complex128
         )
         self.zenith_Eabs = np.zeros(self.Nfreq, dtype=np.float64)
-        pyssht.generate_dl(np.pi / 2.0, self.L_data)
+        sshtn.generate_dl(np.pi / 2.0, self.L_data)
 
         for ii in range(self.Nfreq):
             data = np.loadtxt(self.data_files[ii], skiprows=2)
@@ -132,12 +132,18 @@ class CSTDataProcessor(object):
             pos1_E = (Et + 1j * Ep) / np.sqrt(2.0)
             neg1_E = (Et - 1j * Ep) / np.sqrt(2.0)
 
-            pos1_Elm = pyssht.forward(
-                pos1_E, self.L_data, Spin=1, Method="MWSS", Reality=False
-            )
-            neg1_Elm = pyssht.forward(
-                neg1_E, self.L_data, Spin=-1, Method="MWSS", Reality=False
-            )
+            pos1_Elm = np.empty(self.L_data * self.L_data, dtype=np.complex128)
+            sshtn.mw_forward_sov_conv_sym_ss(pos1_E, self.L_data, 1, pos1_Elm)
+
+            neg1_elm = np.empty(self.L_data * self.L_data, dtype=np.complex128)
+            sshtn.mw_forward_sov_conv_sym_ss(neg1_e, self.L_data, -1, neg1_Elm)
+
+            # pos1_Elm = pyssht.forward(
+            #     pos1_E, self.L_data, Spin=1, Method="MWSS", Reality=False
+            # )
+            # neg1_Elm = pyssht.forward(
+            #     neg1_E, self.L_data, Spin=-1, Method="MWSS", Reality=False
+            # )
 
             self.pos1_Elm_nodes[ii] = pos1_Elm
             self.neg1_Elm_nodes[ii] = neg1_Elm

--- a/src/spin1_beam_model/jones_matrix_field.py
+++ b/src/spin1_beam_model/jones_matrix_field.py
@@ -1,7 +1,7 @@
 import h5py
 import numba as nb
 import numpy as np
-import pyssht
+import ssht_numba as sshtn
 from scipy.interpolate import Rbf, RectBivariateSpline, interp1d
 
 
@@ -54,7 +54,7 @@ class AntennaFarFieldResponse:
 
         rotation_operator = np.zeros(self.L_model ** 2, dtype=np.complex128)
         for ii in range(rotation_operator.size):
-            el, m = pyssht.ind2elm(ii)
+            el, m = sshtn.ind2elm(ii)
             arg = m * rot_angle
             rotation_operator[ii] = np.cos(arg) - 1j * np.sin(arg)
 
@@ -155,7 +155,7 @@ class AntennaFarFieldResponse:
 
         zth = self.zenith_theta
         zph = self.zenith_phi
-        delta = pyssht.generate_dl(np.pi / 2.0, self.L_model)
+        delta = sshtn.generate_dl(np.pi / 2.0, self.L_model)
 
         zen_Eabs = np.zeros(nu_axis.size)
         for ii in range(nu_axis.size):
@@ -294,9 +294,8 @@ class AntennaFarFieldResponse:
                 "of the model (L_synth > L_model)."
             )
 
-        theta_axis, phi_axis = pyssht.sample_positions(
-            L_synth, Method="MWSS", Grid=False
-        )
+        theta_axis, phi_axis = sshtn.sample_positions(L_synth)
+
         mu_axis = np.cos(theta_axis)
 
         mu_axis_flip = np.flipud(mu_axis)
@@ -338,12 +337,11 @@ class AntennaFarFieldResponse:
             pos1_Elm_pad = pad_Elm(pos1_Elm, L_synth)
             neg1_Elm_pad = pad_Elm(neg1_Elm, L_synth)
 
-            pos1_E = pyssht.inverse(
-                pos1_Elm_pad, L_synth, Spin=1, Method="MWSS", Reality=False
-            )
-            neg1_E = pyssht.inverse(
-                neg1_Elm_pad, L_synth, Spin=-1, Method="MWSS", Reality=False
-            )
+            pos1_E = np.empty(sshtn.mwss_sample_shape(L_synth), dtype=np.complex128)
+            sshtn.mw_inverse_sov_sym_ss(pos1_Elm_pad, L_synth, 1, pos1_E)
+
+            neg1_E = np.empty(sstn.mwss_sample_shape(L_synth), dtype=np.complex128)
+            sshtn.mw_inverse_sov_sym_ss(neg1_Elm_pad, L_synth, -1, neg1_E)
 
             Et = (pos1_E + neg1_E) / np.sqrt(2.0)
             Ep = (pos1_E - neg1_E) * (-1j) / np.sqrt(2.0)


### PR DESCRIPTION
Reverts the previous revert, turned out the only thing that was wrong was the spin argument in the spin -1 transform